### PR TITLE
Bug fix in gyroscope.js - defined eventTimerId

### DIFF
--- a/www/gyroscope.js
+++ b/www/gyroscope.js
@@ -19,6 +19,7 @@ var timers = {};
 
 // Array of listeners; used to keep track of when we should call start and stop.
 var listeners = [];
+var eventTimerId = null;
 
 // Last returned speed object from native
 var speed = null;


### PR DESCRIPTION
defined eventTimerId to fix a bug when unwatching - at least when deployed on android devices.
Otherwise clearWatch will throw an exception.
